### PR TITLE
Handle different versions X-parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_script:
 install:
 - npm install
 scripts:
-- npm test
+- npm run lint
 after_script:
 - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -36,8 +36,17 @@ export default ({pool, alephLibrary, alephXServiceUrl, indexingPriority}) => {
 	return async (req, res) => {
 		const reqPayload = await readPayload(req);
 
-		req.isRecordUpdate = /op=update_doc/.test(reqPayload) && /doc_number=0{9}/.test(reqPayload) === false;
-
+		// req.isRecordUpdate = /op=update_doc/.test(reqPayload) && /doc_number=0{9}/.test(reqPayload) === false;
+		
+		req.isRecordUpdate = (/op=update_doc/.test(reqPayload) || /op=update-doc/.test(reqPayload) ) && 
+                                     (/doc_number=0{9}/.test(reqPayload) === false) && 
+                                     (/doc_num=0{9}/.test(reqPayload) === false) && 
+                                     (/rec_num= /.test(reqPayload) === false); 
+		
+		logger.log('debug', req.isRecordUpdate ?
+			   `Request is record update.` :
+			   `Request is not record update.`);
+		
 		proxy.web(req, res, {
 			target: alephXServiceUrl,
 			changeOrigin: true,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -36,17 +36,15 @@ export default ({pool, alephLibrary, alephXServiceUrl, indexingPriority}) => {
 	return async (req, res) => {
 		const reqPayload = await readPayload(req);
 
-		// req.isRecordUpdate = /op=update_doc/.test(reqPayload) && /doc_number=0{9}/.test(reqPayload) === false;
-		
-		req.isRecordUpdate = (/op=update_doc/.test(reqPayload) || /op=update-doc/.test(reqPayload) ) && 
-                                     (/doc_number=0{9}/.test(reqPayload) === false) && 
-                                     (/doc_num=0{9}/.test(reqPayload) === false) && 
-                                     (/rec_num= /.test(reqPayload) === false); 
-		
+		req.isRecordUpdate = (/op=update_doc/.test(reqPayload) || /op=update-doc/.test(reqPayload)) &&
+							(/doc_number=0{9}/.test(reqPayload) === false) &&
+							(/doc_num=0{9}/.test(reqPayload) === false) &&
+							(/rec_num= /.test(reqPayload) === false);
+
 		logger.log('debug', req.isRecordUpdate ?
-			   `Request is record update.` :
-			   `Request is not record update.`);
-		
+			'Request is record update.' :
+			'Request is not record update.');
+
 		proxy.web(req, res, {
 			target: alephXServiceUrl,
 			changeOrigin: true,


### PR DESCRIPTION
Recognize record updates when alternate parameters are used in request to X-server:
- **update-doc** and **update_doc** for op-parameter
- **doc_number**, **doc_num** and **rec_num** for record id